### PR TITLE
Add Clausthal University of Technology to map

### DIFF
--- a/adopters.geojson
+++ b/adopters.geojson
@@ -6,6 +6,7 @@
     {"type": "Feature", "properties": {"institution": "BHT University of Applied Sciences"}, "geometry": {"type": "Point", "coordinates": [13.3531956, 52.5447462]}},
     {"type": "Feature", "properties": {"institution": "University of Vechta"}, "geometry": {"type": "Point", "coordinates": [8.2937678, 52.7211561]}},
     {"type": "Feature", "properties": {"institution": "University of Wismar"}, "geometry": {"type": "Point", "coordinates": [11.44578, 53.88987]}},
-    {"type": "Feature", "properties": {"institution": "Chemnitz University of Technology"}, "geometry": {"type": "Point", "coordinates": [12.92812, 50.83889]}}
+    {"type": "Feature", "properties": {"institution": "Chemnitz University of Technology"}, "geometry": {"type": "Point", "coordinates": [12.92812, 50.83889]}},
+    {"type": "Feature", "properties": {"institution": "Clausthal University of Technology"}, "geometry": {"type": "Point", "coordinates": [10.3425,51.8048]}}
   ]
 }


### PR DESCRIPTION
Should point approximately to Erzstraße 18, 38678 Clausthal-Zellerfeld, just like our own [campus map layer](https://www.tu-clausthal.de/universitaet/kontakt-service/campuskarte?Show=0606)